### PR TITLE
Rename OperatorValidator.check_non_deterministic_enabled() into .chec…

### DIFF
--- a/src/operators_validator.rs
+++ b/src/operators_validator.rs
@@ -504,16 +504,16 @@ impl OperatorValidator {
     }
 
     #[cfg(feature = "deterministic")]
-    fn check_non_deterministic_enabled(&self) -> OperatorValidatorResult<()> {
-        if !self.config.deterministic_only {
-            return Err("deterministic_only support is not enabled");
+    fn check_deterministic_only(&self) -> OperatorValidatorResult<()> {
+        if self.config.deterministic_only {
+            return Err("only deterministic operations are allowed");
         }
         Ok(())
     }
 
     #[inline(always)]
     #[cfg(not(feature = "deterministic"))]
-    fn check_non_deterministic_enabled(&self) -> OperatorValidatorResult<()> {
+    fn check_deterministic_only(&self) -> OperatorValidatorResult<()> {
         Ok(())
     }
 
@@ -812,13 +812,13 @@ impl OperatorValidator {
                 self.func_state.change_frame_with_type(1, Type::I64)?;
             }
             Operator::F32Load { ref memarg } => {
-                self.check_non_deterministic_enabled()?;
+                self.check_deterministic_only()?;
                 self.check_memarg(memarg, 2, resources)?;
                 self.check_operands_1(Type::I32)?;
                 self.func_state.change_frame_with_type(1, Type::F32)?;
             }
             Operator::F64Load { ref memarg } => {
-                self.check_non_deterministic_enabled()?;
+                self.check_deterministic_only()?;
                 self.check_memarg(memarg, 3, resources)?;
                 self.check_operands_1(Type::I32)?;
                 self.func_state.change_frame_with_type(1, Type::F64)?;
@@ -884,13 +884,13 @@ impl OperatorValidator {
                 self.func_state.change_frame(2)?;
             }
             Operator::F32Store { ref memarg } => {
-                self.check_non_deterministic_enabled()?;
+                self.check_deterministic_only()?;
                 self.check_memarg(memarg, 2, resources)?;
                 self.check_operands_2(Type::I32, Type::F32)?;
                 self.func_state.change_frame(2)?;
             }
             Operator::F64Store { ref memarg } => {
-                self.check_non_deterministic_enabled()?;
+                self.check_deterministic_only()?;
                 self.check_memarg(memarg, 3, resources)?;
                 self.check_operands_2(Type::I32, Type::F64)?;
                 self.func_state.change_frame(2)?;
@@ -936,11 +936,11 @@ impl OperatorValidator {
             Operator::I32Const { .. } => self.func_state.change_frame_with_type(0, Type::I32)?,
             Operator::I64Const { .. } => self.func_state.change_frame_with_type(0, Type::I64)?,
             Operator::F32Const { .. } => {
-                self.check_non_deterministic_enabled()?;
+                self.check_deterministic_only()?;
                 self.func_state.change_frame_with_type(0, Type::F32)?;
             }
             Operator::F64Const { .. } => {
-                self.check_non_deterministic_enabled()?;
+                self.check_deterministic_only()?;
                 self.func_state.change_frame_with_type(0, Type::F64)?;
             }
             Operator::I32Eqz => {
@@ -983,7 +983,7 @@ impl OperatorValidator {
             | Operator::F32Gt
             | Operator::F32Le
             | Operator::F32Ge => {
-                self.check_non_deterministic_enabled()?;
+                self.check_deterministic_only()?;
                 self.check_operands_2(Type::F32, Type::F32)?;
                 self.func_state.change_frame_with_type(2, Type::I32)?;
             }
@@ -993,7 +993,7 @@ impl OperatorValidator {
             | Operator::F64Gt
             | Operator::F64Le
             | Operator::F64Ge => {
-                self.check_non_deterministic_enabled()?;
+                self.check_deterministic_only()?;
                 self.check_operands_2(Type::F64, Type::F64)?;
                 self.func_state.change_frame_with_type(2, Type::I32)?;
             }
@@ -1048,7 +1048,7 @@ impl OperatorValidator {
             | Operator::F32Trunc
             | Operator::F32Nearest
             | Operator::F32Sqrt => {
-                self.check_non_deterministic_enabled()?;
+                self.check_deterministic_only()?;
                 self.check_operands_1(Type::F32)?;
                 self.func_state.change_frame_with_type(1, Type::F32)?;
             }
@@ -1059,7 +1059,7 @@ impl OperatorValidator {
             | Operator::F32Min
             | Operator::F32Max
             | Operator::F32Copysign => {
-                self.check_non_deterministic_enabled()?;
+                self.check_deterministic_only()?;
                 self.check_operands_2(Type::F32, Type::F32)?;
                 self.func_state.change_frame_with_type(2, Type::F32)?;
             }
@@ -1070,7 +1070,7 @@ impl OperatorValidator {
             | Operator::F64Trunc
             | Operator::F64Nearest
             | Operator::F64Sqrt => {
-                self.check_non_deterministic_enabled()?;
+                self.check_deterministic_only()?;
                 self.check_operands_1(Type::F64)?;
                 self.func_state.change_frame_with_type(1, Type::F64)?;
             }
@@ -1081,7 +1081,7 @@ impl OperatorValidator {
             | Operator::F64Min
             | Operator::F64Max
             | Operator::F64Copysign => {
-                self.check_non_deterministic_enabled()?;
+                self.check_deterministic_only()?;
                 self.check_operands_2(Type::F64, Type::F64)?;
                 self.func_state.change_frame_with_type(2, Type::F64)?;
             }
@@ -1110,32 +1110,32 @@ impl OperatorValidator {
                 self.func_state.change_frame_with_type(1, Type::I64)?;
             }
             Operator::F32ConvertSI32 | Operator::F32ConvertUI32 => {
-                self.check_non_deterministic_enabled()?;
+                self.check_deterministic_only()?;
                 self.check_operands_1(Type::I32)?;
                 self.func_state.change_frame_with_type(1, Type::F32)?;
             }
             Operator::F32ConvertSI64 | Operator::F32ConvertUI64 => {
-                self.check_non_deterministic_enabled()?;
+                self.check_deterministic_only()?;
                 self.check_operands_1(Type::I64)?;
                 self.func_state.change_frame_with_type(1, Type::F32)?;
             }
             Operator::F32DemoteF64 => {
-                self.check_non_deterministic_enabled()?;
+                self.check_deterministic_only()?;
                 self.check_operands_1(Type::F64)?;
                 self.func_state.change_frame_with_type(1, Type::F32)?;
             }
             Operator::F64ConvertSI32 | Operator::F64ConvertUI32 => {
-                self.check_non_deterministic_enabled()?;
+                self.check_deterministic_only()?;
                 self.check_operands_1(Type::I32)?;
                 self.func_state.change_frame_with_type(1, Type::F64)?;
             }
             Operator::F64ConvertSI64 | Operator::F64ConvertUI64 => {
-                self.check_non_deterministic_enabled()?;
+                self.check_deterministic_only()?;
                 self.check_operands_1(Type::I64)?;
                 self.func_state.change_frame_with_type(1, Type::F64)?;
             }
             Operator::F64PromoteF32 => {
-                self.check_non_deterministic_enabled()?;
+                self.check_deterministic_only()?;
                 self.check_operands_1(Type::F32)?;
                 self.func_state.change_frame_with_type(1, Type::F64)?;
             }
@@ -1148,12 +1148,12 @@ impl OperatorValidator {
                 self.func_state.change_frame_with_type(1, Type::I64)?;
             }
             Operator::F32ReinterpretI32 => {
-                self.check_non_deterministic_enabled()?;
+                self.check_deterministic_only()?;
                 self.check_operands_1(Type::I32)?;
                 self.func_state.change_frame_with_type(1, Type::F32)?;
             }
             Operator::F64ReinterpretI64 => {
-                self.check_non_deterministic_enabled()?;
+                self.check_deterministic_only()?;
                 self.check_operands_1(Type::I64)?;
                 self.func_state.change_frame_with_type(1, Type::F64)?;
             }
@@ -1356,13 +1356,13 @@ impl OperatorValidator {
                 self.func_state.change_frame_with_type(1, Type::V128)?;
             }
             Operator::F32x4Splat => {
-                self.check_non_deterministic_enabled()?;
+                self.check_deterministic_only()?;
                 self.check_simd_enabled()?;
                 self.check_operands_1(Type::F32)?;
                 self.func_state.change_frame_with_type(1, Type::V128)?;
             }
             Operator::F64x2Splat => {
-                self.check_non_deterministic_enabled()?;
+                self.check_deterministic_only()?;
                 self.check_simd_enabled()?;
                 self.check_operands_1(Type::F64)?;
                 self.func_state.change_frame_with_type(1, Type::V128)?;
@@ -1416,28 +1416,28 @@ impl OperatorValidator {
                 self.func_state.change_frame_with_type(2, Type::V128)?;
             }
             Operator::F32x4ExtractLane { lane } => {
-                self.check_non_deterministic_enabled()?;
+                self.check_deterministic_only()?;
                 self.check_simd_enabled()?;
                 self.check_simd_lane_index(lane, 4)?;
                 self.check_operands_1(Type::V128)?;
                 self.func_state.change_frame_with_type(1, Type::F32)?;
             }
             Operator::F32x4ReplaceLane { lane } => {
-                self.check_non_deterministic_enabled()?;
+                self.check_deterministic_only()?;
                 self.check_simd_enabled()?;
                 self.check_simd_lane_index(lane, 4)?;
                 self.check_operands_2(Type::V128, Type::F32)?;
                 self.func_state.change_frame_with_type(2, Type::V128)?;
             }
             Operator::F64x2ExtractLane { lane } => {
-                self.check_non_deterministic_enabled()?;
+                self.check_deterministic_only()?;
                 self.check_simd_enabled()?;
                 self.check_simd_lane_index(lane, 2)?;
                 self.check_operands_1(Type::V128)?;
                 self.func_state.change_frame_with_type(1, Type::F64)?;
             }
             Operator::F64x2ReplaceLane { lane } => {
-                self.check_non_deterministic_enabled()?;
+                self.check_deterministic_only()?;
                 self.check_simd_enabled()?;
                 self.check_simd_lane_index(lane, 2)?;
                 self.check_operands_2(Type::V128, Type::F64)?;
@@ -1467,7 +1467,7 @@ impl OperatorValidator {
             | Operator::F64x2Div
             | Operator::F64x2Min
             | Operator::F64x2Max => {
-                self.check_non_deterministic_enabled()?;
+                self.check_deterministic_only()?;
                 self.check_simd_enabled()?;
                 self.check_operands_2(Type::V128, Type::V128)?;
                 self.func_state.change_frame_with_type(2, Type::V128)?;
@@ -1538,7 +1538,7 @@ impl OperatorValidator {
             | Operator::F32x4ConvertUI32x4
             | Operator::F64x2ConvertSI64x2
             | Operator::F64x2ConvertUI64x2 => {
-                self.check_non_deterministic_enabled()?;
+                self.check_deterministic_only()?;
                 self.check_simd_enabled()?;
                 self.check_operands_1(Type::V128)?;
                 self.func_state.change_frame_with_type(1, Type::V128)?;


### PR DESCRIPTION
…k_deterministic_only(), and fix it to return Err properly